### PR TITLE
Code cleanup, better negative examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Installation:
    images:
     ```
     cd scripts/node
-    npm install googlemaps easyimage fast-csv
+    npm install googlemaps easyimage fast-csv turf @turf/invariant
     mkdir -p ../../images/crater ../../images/no_crater
     ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Installation:
     ```
     cd images/crater
     find . -type f -print0 | xargs -0 -n 1 -P 6 -I {} sh -c "gm convert {} -quality 90 {}.jpg && rm {}"
-    cd images/no_crater
+    cd ../images/no_crater
     find . -type f -print0 | xargs -0 -n 1 -P 6 -I {} sh -c "gm convert {} -quality 90 {}.jpg && rm {}"
     ```
 

--- a/README.md
+++ b/README.md
@@ -47,15 +47,23 @@ This should take about 10 minutes to collect approximately 2000
 images.
 
 4. Run random_scraper.js to gather satellite imagery of random places.
+
+5. Convert the PNG images to JPG:
+
+```
+cd images/crater
+find . -type f -print0 | xargs -0 -n 1 -P 6 -I {} sh -c "gm convert {} -quality 90 {}.jpg && rm {}"
+cd images/no_crater
+find . -type f -print0 | xargs -0 -n 1 -P 6 -I {} sh -c "gm convert {} -quality 90 {}.jpg && rm {}"
+```
+
 5. Train the model:
 ```
 python tensorflow/tensorflow/examples/image_retraining/retrain.py \
---bottleneck_dir=./tf_files/bottlenecks \
---how_many_training_steps 500 \
---model_dir=./tf_files/crater_inception \
+--how_many_training_steps 40000 \
 --output_graph=./tf_files/retrained_graph.pb \
 --output_labels=./tf_files/retrained_labels.txt \
---image_dir=./tf_files/test_sites
+--image_dir=images
 ``
 
 5. run tf-classifier

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # Crater-Scraper / Crater Classification
-Identifying Craters left from wepons test using Convolutional Neural Network.
 
-Crater Scraping is an ongoing research project that seeks to train a Convolutional Neural Network to identify and classify nuclear weapons test sites. Crater Scraping works by utilizing information from FOIA requests and research from military historians to scrape satellite imagery of weapons test sites. Images are then used to train a Neural Network to identify and classify man made geological events from satellite imagery. 
+Identifying Craters left from wepons test using Convolutional Neural
+Network.
+
+Crater Scraping is an ongoing research project that seeks to train a
+Convolutional Neural Network to identify and classify nuclear weapons
+test sites. Crater Scraping works by utilizing information from FOIA
+requests and research from military historians to scrape satellite
+imagery of weapons test sites. Images are then used to train a Neural
+Network to identify and classify man made geological events from
+satellite imagery.
 
 ![Alt text](./1.jpeg "")
 ![Alt text](./2.jpeg "")
@@ -14,36 +22,62 @@ Crater Scraping is an ongoing research project that seeks to train a Convolution
 
 Installation:
 
-1. You need dlib and scikit-image.
-2. Run node scraper.js to gather nuclear test site images
-3. Run random_scraper.js to gather satellite imagery of random places
-4. Run python tensorflow/tensorflow/examples/image_retraining/retrain.py \
-—bottleneck_dir=./tf_files/bottlenecks \
-—how_many_training_steps 500 \
-—model_dir=./tf_files/crater_inception \
-—output_graph=./tf_files/retrained_graph.pb \
-—output_labels=./tf_files/retrained_labels.txt \
-—image_dir=./tf_files/test_sites
+1. Install dlib, scikit-image and tensorflow.
 
-5. run tf-classifier 
+2. Install the node prerequisites and create a directory to hold
+   images:
+```
+cd scripts/node
+npm install googlemaps easyimage fast-csv
+mkdir -p ../../images/crater ../../images/no_crater
+```
+
+3. Generate a Google Static Maps API key by going to
+   the
+   [Google Static Maps API page](https://developers.google.com/maps/documentation/static-maps/) and
+   clicking the "GET KEY" button. Put the key in
+   `scripts/node/config.js`.
+
+3. Run scraper.js to gather nuclear test site images:
+```
+node scraper.js
+```
+
+This should take about 10 minutes to collect approximately 2000
+images.
+
+4. Run random_scraper.js to gather satellite imagery of random places.
+5. Train the model:
+```
+python tensorflow/tensorflow/examples/image_retraining/retrain.py \
+--bottleneck_dir=./tf_files/bottlenecks \
+--how_many_training_steps 500 \
+--model_dir=./tf_files/crater_inception \
+--output_graph=./tf_files/retrained_graph.pb \
+--output_labels=./tf_files/retrained_labels.txt \
+--image_dir=./tf_files/test_sites
+``
+
+5. run tf-classifier
 
 -----------------------------------
 
-11/23 - Script to collect a google map of crater site and save as cropped image. 
-11/24 - Script to convert crater images into Histogram of Oriented Gradients.
-11/25 - Compiled CSVs of nuclear tests and coordinates
-11/26 - Gathered all images...around 2000
-12/3 - Convolution with Tensorflow
-12/5 - Neural Net with tensor flow
-12/7 - retrain.py to train the final layer of a pretrained inception model
-12/9 - classifying images
+* 11/23 - Script to collect a google map of crater site and save as cropped image.
+* 11/24 - Script to convert crater images into Histogram of Oriented Gradients.
+* 11/25 - Compiled CSVs of nuclear tests and coordinates
+* 11/26 - Gathered all images...around 2000
+* 12/3 - Convolution with Tensorflow
+* 12/5 - Neural Net with tensor flow
+* 12/7 - retrain.py to train the final layer of a pretrained inception model
+* 12/9 - classifying images
 
-*** current status ***
+## Current status
 
-This works to identify craters with better than average results.  However, it is easy to fool if you feed an image of a desert to the network. Still is valuable code if all you want to do is scrape all 2000 images.
+This works to identify craters with better than average results.
+However, it is easy to fool if you feed an image of a desert to the
+network. Still is valuable code if all you want to do is scrape all
+2000 images.
 
 Thanks to johnston archives.
 
 http://www.johnstonsarchive.net/nuclear/tests/
-
-

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Installation:
 
 2. Install the node prerequisites and create a directory to hold
    images:
-```
-cd scripts/node
-npm install googlemaps easyimage fast-csv
-mkdir -p ../../images/crater ../../images/no_crater
-```
+    ```
+    cd scripts/node
+    npm install googlemaps easyimage fast-csv
+    mkdir -p ../../images/crater ../../images/no_crater
+    ```
 
 3. Generate a Google Static Maps API key by going to
    the
@@ -39,9 +39,9 @@ mkdir -p ../../images/crater ../../images/no_crater
    `scripts/node/config.js`.
 
 3. Run scraper.js to gather nuclear test site images:
-```
-node scraper.js
-```
+    ```
+    node scraper.js
+    ```
 
 This should take about 10 minutes to collect approximately 2000
 images.
@@ -64,7 +64,7 @@ python tensorflow/tensorflow/examples/image_retraining/retrain.py \
 --output_graph=./tf_files/retrained_graph.pb \
 --output_labels=./tf_files/retrained_labels.txt \
 --image_dir=images
-``
+```
 
 5. run tf-classifier
 

--- a/README.md
+++ b/README.md
@@ -43,41 +43,51 @@ Installation:
     node scraper.js
     ```
 
-This should take about 10 minutes to collect approximately 2000
-images.
+    This should take about 10 minutes to collect approximately 2000
+    images.
 
 4. Run random_scraper.js to gather satellite imagery of random places.
 
 5. Convert the PNG images to JPG:
 
-```
-cd images/crater
-find . -type f -print0 | xargs -0 -n 1 -P 6 -I {} sh -c "gm convert {} -quality 90 {}.jpg && rm {}"
-cd images/no_crater
-find . -type f -print0 | xargs -0 -n 1 -P 6 -I {} sh -c "gm convert {} -quality 90 {}.jpg && rm {}"
-```
+    ```
+    cd images/crater
+    find . -type f -print0 | xargs -0 -n 1 -P 6 -I {} sh -c "gm convert {} -quality 90 {}.jpg && rm {}"
+    cd images/no_crater
+    find . -type f -print0 | xargs -0 -n 1 -P 6 -I {} sh -c "gm convert {} -quality 90 {}.jpg && rm {}"
+    ```
 
 5. Train the model:
-```
-python tensorflow/tensorflow/examples/image_retraining/retrain.py \
---how_many_training_steps 40000 \
---output_graph=./tf_files/retrained_graph.pb \
---output_labels=./tf_files/retrained_labels.txt \
---image_dir=images
-```
+    ```
+    python ~/tensorflow/tensorflow/examples/image_retraining/retrain.py \
+      --how_many_training_steps 4000 \
+      --output_graph=crater_graph.pb \
+      --output_labels=crater_labels.txt \
+      --image_dir=images
+    ```
 
-5. run tf-classifier
+5. Run the classifier on a new image:
+    ```
+    $ ~/tensorflow/bazel-bin/tensorflow/examples/label_image/label_image \
+      --graph=crater_graph.pb \
+      --labels=crater_labels.txt \
+      --output_layer=final_result \
+      --image=1.jpg \
+      --input_layer=Mul
+    2017-04-05 15:58:38.495479: I tensorflow/examples/label_image/main.cc:206] crater (1): 0.938558
+    2017-04-05 15:58:38.495497: I tensorflow/examples/label_image/main.cc:206] no crater (0): 0.0614419
+    ```
 
 -----------------------------------
 
-* 11/23 - Script to collect a google map of crater site and save as cropped image.
-* 11/24 - Script to convert crater images into Histogram of Oriented Gradients.
-* 11/25 - Compiled CSVs of nuclear tests and coordinates
-* 11/26 - Gathered all images...around 2000
-* 12/3 - Convolution with Tensorflow
-* 12/5 - Neural Net with tensor flow
-* 12/7 - retrain.py to train the final layer of a pretrained inception model
-* 12/9 - classifying images
+* 11/23/2016 - Script to collect a google map of crater site and save as cropped image.
+* 11/24/2016 - Script to convert crater images into Histogram of Oriented Gradients.
+* 11/25/2016 - Compiled CSVs of nuclear tests and coordinates
+* 11/26/2016 - Gathered all images...around 2000
+* 12/3/2016 - Convolution with Tensorflow
+* 12/5/2016 - Neural Net with tensor flow
+* 12/7/2016 - retrain.py to train the final layer of a pretrained inception model
+* 12/9/2016 - classifying images
 
 ## Current status
 

--- a/scripts/node/config.js
+++ b/scripts/node/config.js
@@ -1,0 +1,7 @@
+exports.googleMapsApiConfig = {
+  // See the README for instructions on generating an API key.
+  key: 'INSERT YOUR API KEY HERE';
+};
+
+// Wait 200 ms between Google Maps API calls.
+exports.waitPerApiCall = 200;

--- a/scripts/node/random_scraper.js
+++ b/scripts/node/random_scraper.js
@@ -1,43 +1,65 @@
 var GoogleMapsAPI = require('./node_modules/googlemaps/lib/index');
-var fs = require('fs')
-var google = new GoogleMapsAPI();
-var cropper = require('easyimage')
-var cleaner = require('./cleaner.js')
-var _ = require('underscore')
+var fs = require('fs');
+var cropper = require('easyimage');
+var cleaner = require('./cleaner.js');
+var config = require('./config-2.js');
+var _ = require('underscore');
 
- 
-var sites = cleaner.begin()
+var google = new GoogleMapsAPI(config.googleMapsApiConfig);
 
-setTimeout(function() { run(sites.sanitized_craters)}, 10000)
+var sites = cleaner.begin();
 
-function run(data){
+setTimeout(function() { run(sites.sanitized_craters); }, 1000);
+
+function run(data) {
   var d = data;
- console.log('su')
-  _.each(d,function(v,k){
-      var params = {
-        zoom: 15,
-        size: '500x400',
-        maptype: 'satellite',
-        center:getRandomInRange(-180, 180, 3) + " " + getRandomInRange(-180, 180, 3)
-      };
-      google.staticMap(params, function(err, binaryImage) {
-        
-        fs.writeFile("../test/"+v['SERIES']+v['YEAR']+k+".jpg", binaryImage, 'binary', function(err){
-          if (err) throw err   
-          cropper.rescrop({
-               src:v['SERIES']+v['YEAR']+k, dst:v['SERIES']+v['YEAR']+k,
-               width:500, height:400,
-               cropwidth:500, cropheight:350,
-            }).then(
-            function (err) {
-              console.log(err);
+  var n = 0;
+  _.each(d, function(v, k) {
+    var params = {
+      zoom: 15,
+      size: '500x400',
+      maptype: 'satellite',
+      center:getRandomInRange(-180, 180, 3) + " " + getRandomInRange(-180, 180, 3)
+    };
+    var filename = '../../images/no_crater/' +v['SERIES'] + v['YEAR'] + k + '.png';
+    filename = filename.replace(' ', '_');
+    if (!fs.existsSync(filename)) {
+      n += 1;
+      setTimeout(
+        function(v, k, params, filename) {
+          google.staticMap(params, function(err, binaryImage) {
+            if (!binaryImage) {
+              console.log('Skipping ' + filename + '; Bad response');
+              return;
             }
-          );
-        })
-      });
-  })
+            if (err) {
+              console.log('Skipping ' + filename + '; Error: ' + err);
+              return;
+            }
+            console.log('Writing ' + filename);
+            console.log(params.center);
+            fs.writeFile(filename, binaryImage, 'binary', function(err){
+              cropper.rescrop({
+                src:v['SERIES']+v['YEAR']+k, dst:v['SERIES']+v['YEAR']+k,
+                width:500, height:400,
+                cropwidth:500, cropheight:350,
+              }).then(
+                function (err) {
+                  console.log(err);
+                }
+              );
+            });
+          });
+        },
+        n * config.waitPerApiCall,
+        v, k, params, filename);
+    } else {
+      console.log('Skipping ' + filename + '; already exists.');
+    }
+  });
 }
+
 function getRandomInRange(from, to, fixed) {
-    return (Math.random() * (to - from) + from).toFixed(fixed) * 1;
-    // .toFixed() returns string, so ' * 1' is a trick to convert to number
+  return (Math.random() * (to - from) + from).toFixed(fixed) * 1;
+  // .toFixed() returns string, so ' * 1' is a trick to convert to number
 }

--- a/scripts/node/random_scraper.js
+++ b/scripts/node/random_scraper.js
@@ -2,9 +2,10 @@ var GoogleMapsAPI = require('./node_modules/googlemaps/lib/index');
 var fs = require('fs');
 var cropper = require('easyimage');
 var cleaner = require('./cleaner.js');
-var config = require('./config-2.js');
+var config = require('./config.js');
 var _ = require('underscore');
-
+var turf = require('turf');
+var getCoords = require('@turf/invariant').getCoords;
 var google = new GoogleMapsAPI(config.googleMapsApiConfig);
 
 var sites = cleaner.begin();
@@ -13,13 +14,21 @@ setTimeout(function() { run(sites.sanitized_craters); }, 1000);
 
 function run(data) {
   var d = data;
+  var picker = new PointPicker(d);
   var n = 0;
   _.each(d, function(v, k) {
+    // Find an image near the crater that doesn't actually contain the
+    // crater. For each known crater, we choose a random point that is
+    // between 5 and 20 miles from that crater, and is no closer than
+    // 5 miles to any other known craters.
+    var p = picker.nearbyPoint(v, 5, 20, 1000);
+    var coords = getCoords(p);
+    var center = coords[1].toFixed(6) + ' ' + coords[0].toFixed(6);
     var params = {
       zoom: 15,
       size: '500x400',
       maptype: 'satellite',
-      center:getRandomInRange(-180, 180, 3) + " " + getRandomInRange(-180, 180, 3)
+      center: center
     };
     var filename = '../../images/no_crater/' +v['SERIES'] + v['YEAR'] + k + '.png';
     filename = filename.replace(' ', '_');
@@ -42,7 +51,7 @@ function run(data) {
               cropper.rescrop({
                 src:v['SERIES']+v['YEAR']+k, dst:v['SERIES']+v['YEAR']+k,
                 width:500, height:400,
-                cropwidth:500, cropheight:350,
+                cropwidth:500, cropheight:350
               }).then(
                 function (err) {
                   console.log(err);
@@ -62,4 +71,51 @@ function run(data) {
 function getRandomInRange(from, to, fixed) {
   return (Math.random() * (to - from) + from).toFixed(fixed) * 1;
   // .toFixed() returns string, so ' * 1' is a trick to convert to number
+}
+
+function PointPicker(d) {
+  this.points = _.map(
+    d,
+    function(v) {
+      var p = turf.point([v['LONG'], v['LAT']]);
+      return p;
+    });
+}
+
+PointPicker.prototype.nearbyPoint = function(d, minDist, maxDist, maxIter) {
+  return this.nearbyPointIter(turf.point([d['LONG'], d['LAT']]), minDist, maxDist, maxIter, 0);
+};
+
+PointPicker.prototype.nearbyPointIter = function(p, minDist, maxDist, maxIter, iter) {
+  if (iter > maxIter) {
+    return null;
+  }
+  var dist = getRandomInRange(minDist, maxDist);
+  var bearing = getRandomInRange(-180, 180);
+  var dest = turf.destination(p, dist, bearing, 'miles');
+  if (this.tooClose(dest, minDist)) {
+    return this.nearbyPointIter(p, minDist, maxDist, maxIter, iter + 1);
+  } else {
+    return dest;
+  }
+};
+
+PointPicker.prototype.tooClose = function(p, minDist) {
+  var points = this.points;
+  var closestDistance = 10000;
+  for (var i = 0; i < points.length; i++) {
+    var distance = turf.distance(p, points[i], 'miles');
+    if (distance < closestDistance) {
+      closestDistance = distance;
+    }
+    if (distance < minDist) {
+      return true;
+    }
+  }
+  return false;
+};
+
+
+function getRandomInt(min, max) {
+  return Math.floor(Math.random() * (max - min)) + min;
 }


### PR DESCRIPTION
I made the following changes while trying to get the original code running:

* Use a Google Static Maps API key.
* Throttle Maps API calls.
* Check whether the Maps API returns valid data.
* Save images with .png extension.
* Don't re-download images we already have.
* Added missing steps and more detail to the README.

Additionally, I made a modification that attempts to train a better model by using more difficult negative examples.  It seemed that many of the positive examples were desert terrain, while the negative examples were random locations on the globe, resulting in lots of desert imagery coming back as a false positive.  Now, for each known crater location a negative example is created by finding an image of a randomly chosen location that is between 5 and 20 miles from the crater, and is no closer than 5 miles to any known crater.  The intent is to find images of terrain very similar to the terrain that contains craters, but that does not actually contain a crater.
